### PR TITLE
Fix start level

### DIFF
--- a/numerica-puzzle/src/App.tsx
+++ b/numerica-puzzle/src/App.tsx
@@ -278,7 +278,8 @@ function App() {
   };
 
   const handleStartGame = () => {
-    setLevel(101);
+    // Start the game from the very first level
+    setLevel(1);
     setGameState('playing');
     setMainMenuSubView('main'); // Reset subview
   };


### PR DESCRIPTION
## Summary
- start the game at level 1 when pressing **Start**

## Testing
- `npm test -- --run` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869bcfa821083209f40e3890fbda996