### PR TITLE
Fix Next Level after level1

### DIFF
--- a/numerica-puzzle/src/App.tsx
+++ b/numerica-puzzle/src/App.tsx
@@ -218,7 +218,8 @@ function App() {
           setMessage(`Level ${level} Complete!`);
           setAreButtonsClickable(false); // Disable buttons after completion
           setUnlockedLevels(prev => {
-            const newUnlocked = new Set([...prev, level + 1]);
+            const nextLevel = level === 1 ? 101 : level + 1;
+            const newUnlocked = new Set([...prev, nextLevel]);
             return Array.from(newUnlocked).sort((a, b) => a - b);
           });
 
@@ -270,7 +271,9 @@ function App() {
   };
 
   const handleNextLevel = () => {
-    if (level + 1 <= totalLevels) {
+    if (level === 1) {
+      setLevel(101);
+    } else if (level + 1 <= totalLevels) {
       setLevel(prevLevel => prevLevel + 1);
     } else {
       setGameState('menu'); // Go back to menu if all levels are completed


### PR DESCRIPTION
## Summary
- navigate from level 1 directly to level 101 when using Next Level
- correctly unlock the next level after level 1

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6869bf7088088320b5a179146172ed55