### PR TITLE
Overlay checkmark for finished puzzle

### DIFF
--- a/numerica-puzzle/src/App.tsx
+++ b/numerica-puzzle/src/App.tsx
@@ -8,6 +8,7 @@ export enum ButtonState {
   WasPressed = 'was-pressed',
   Disabled = 'disabled',
   Error = 'error',
+  Completed = 'completed',
 }
 
 export interface ButtonData {
@@ -226,7 +227,9 @@ function App() {
           });
 
           return newButtons.map(btn =>
-            btn.id === buttonId ? { ...btn, label: '✅' } : btn
+            btn.id === buttonId
+              ? { ...btn, label: '', state: ButtonState.Completed }
+              : btn
           );
         }
         return newButtons;

--- a/numerica-puzzle/src/components/Button.css
+++ b/numerica-puzzle/src/components/Button.css
@@ -32,8 +32,26 @@
   color: white;
 }
 
-/* Larger checkmark when used as button label */
-.checkmark-label {
-  font-size: 3em;
-  line-height: 1;
+/* Completed state with checkmark overlay */
+.button--completed {
+  position: relative;
+  background-color: #4caf50; /* Green */
+  color: white;
 }
+
+.button--completed .button-label {
+  visibility: hidden;
+}
+
+.button--completed::after {
+  content: '\2713';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: white;
+  font-size: 2em;
+  line-height: 1;
+  pointer-events: none;
+}
+

--- a/numerica-puzzle/src/components/Button.tsx
+++ b/numerica-puzzle/src/components/Button.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import './Button.css';
 
-export type ButtonState = 'pressable' | 'was-pressed' | 'disabled' | 'error';
+export type ButtonState =
+  | 'pressable'
+  | 'was-pressed'
+  | 'disabled'
+  | 'error'
+  | 'completed';
 
 interface ButtonProps {
   state: ButtonState;
@@ -11,15 +16,18 @@ interface ButtonProps {
 }
 
 const Button: React.FC<ButtonProps> = ({ state, onClick, label, disabled }) => {
-  const isCheckmark = label === '✅';
-
   return (
     <button
       className={`button button--${state}`}
       onClick={onClick}
-      disabled={disabled || state === 'disabled' || state === 'was-pressed'}
+      disabled={
+        disabled ||
+        state === 'disabled' ||
+        state === 'was-pressed' ||
+        state === 'completed'
+      }
     >
-      <span className={isCheckmark ? 'checkmark-label' : undefined}>{label}</span>
+      <span className="button-label">{label}</span>
     </button>
   );
 };


### PR DESCRIPTION
## Summary
- overlay a white checkmark when a button completes a puzzle
- support new `completed` button state

## Testing
- `npx -y vitest run --dir numerica-puzzle`

------
https://chatgpt.com/codex/tasks/task_e_6869c792d8bc8320b8242dd3e4457f17